### PR TITLE
fix assignment of res in parallel_inhom_refl

### DIFF
--- a/udkm1Dsim/simulations/xrays.py
+++ b/udkm1Dsim/simulations/xrays.py
@@ -2125,8 +2125,8 @@ class XrayDynMag(Xray):
             RTi_phi = delayed(XrayDynMag.calc_reflectivity_transmissivity_from_matrix)(
                 RT_phi, remote_pol_in, remote_pol_out)
             res.append(RTi[0])
-            res.append(RTi[1])
             res.append(RTi_phi[0])
+            res.append(RTi[1])
             res.append(RTi_phi[1])
 
         # compute results


### PR DESCRIPTION
fix the order of reflectivity/transmissitivy matrix assignment to the result in dask.delayed task creation that was confused by 5b980fa9a497e53e139339edb3eb1598cecc9d94