### PR TITLE
Wrong math for Debye Waller Factor in x-Ray class

### DIFF
--- a/udkm1Dsim/simulations/xrays.py
+++ b/udkm1Dsim/simulations/xrays.py
@@ -1388,7 +1388,7 @@ class XrayDyn(Xray):
         - :math:`P(q_z)` is the polarization factor
         - :math:`A` is the area in :math:`x-y` plane on which the atom
           is placed
-        - :math:`M = 0.5(\mbox{dbf} \ q_z)^2)` where
+        - :math:`M = 0.5 \mbox{dbf} q_z^2` where
           :math:`\mbox{dbf}^2 = \langle u^2\rangle` is the average
           thermal vibration of the atoms - Debye-Waller factor
 
@@ -1404,7 +1404,7 @@ class XrayDyn(Xray):
         rho = (-4j*np.pi*r_0
                * atom.get_cm_atomic_form_factor(self._energy, self._qz)
                * self.get_polarization_factor(self._theta)
-               * np.exp(-0.5*(deb_wal_fac*self._qz)**2))/(self._qz*area)
+               * np.exp(-0.5*deb_wal_fac*self._qz**2)/(self._qz*area)
         return rho
 
     def get_atom_transmission_factor(self, atom, area, deb_wal_fac):
@@ -1419,7 +1419,7 @@ class XrayDyn(Xray):
           (no angle correction)
         - :math:`A` is the area in :math:`x-y` plane on which the atom
           is placed
-        - :math:`M = 0.5(\mbox{dbf} \ q_z)^2` where
+        - :math:`M = 0.5 \mbox{dbf} q_z^2` where
           :math:`\mbox{dbf}^2 = \langle u^2\rangle` is the average
           thermal vibration of the atoms - Debye-Waller factor
 
@@ -1434,7 +1434,7 @@ class XrayDyn(Xray):
         """
         tau = 1 - (4j*np.pi*r_0
                    * atom.get_cm_atomic_form_factor(self._energy, np.zeros_like(self._qz))
-                   * np.exp(-0.5*(deb_wal_fac*self._qz)**2))/(self._qz*area)
+                   * np.exp(-0.5*deb_wal_fac*self._qz**2))/(self._qz*area)
         return tau
 
     def get_atom_phase_matrix(self, distance):


### PR DESCRIPTION
Wrong math in ref/trans factors for Debye Waller Factor: Units cell Class requires de_wal_fac in units of m^2. The math in get_atom_reflection/trasmission_factor, requires the unit of m instead of m^2. Also the comment section shows different equations as used in the function.