### PR TITLE
avoid comparing numpy arrays with empty lists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
     name: CI workflow
     steps:
       - name: checkout source repo
-        uses: actions/checkout@v2      
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: "Installs dependencies"
@@ -42,7 +42,7 @@ jobs:
         run: |
           pytest --cov=./udkm1Dsim --cov-report=xml test/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS, PYTHON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -21,10 +21,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Sets up python
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/dschick/udkm1Dsim',
     install_requires=['tqdm>=4.43.0',
                       'numpy>=1.18.2',
-                      'pint>=0.9',
+                      'pint>=0.23',
                       'scipy>=1.4.1',
                       'sympy>=1.5.1',
                       'tabulate',
@@ -36,6 +36,6 @@ setup(
                 + 'in Condensed Matter',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    python_requires='>=3.5',
+    python_requires='>=3.9',
     keywords='ultrafast dynamics condensed matter 1D',
 )

--- a/udkm1Dsim/simulations/heat.py
+++ b/udkm1Dsim/simulations/heat.py
@@ -1085,7 +1085,7 @@ class Heat(Simulation):
                               'excitation(s): {:f} s'.format(len(fluence), time()-t1))
         else:
             self.disp_message('Elapsed time for _heat_diffusion_: {:f} s'.format(time()-t1))
-            
+
         return temp_map
 
     @staticmethod

--- a/udkm1Dsim/simulations/heat.py
+++ b/udkm1Dsim/simulations/heat.py
@@ -216,10 +216,9 @@ class Heat(Simulation):
         except AttributeError:
             pass
 
-        if distances == []:
+        N = len(distances)
+        if N == 0:
             N = self.S.get_number_of_layers()
-        else:
-            N = len(distances)
 
         K = self.S.num_sub_systems
         # check size of initTemp
@@ -417,7 +416,7 @@ class Heat(Simulation):
         else:
             structure = self.S
 
-        if distances == []:
+        if len(distances) == 0:
             # if no distances are set, calculate the extinction on
             # the middle of each unit cell
             d_start, _, distances = structure.get_distances_of_layers(False)
@@ -507,7 +506,7 @@ class Heat(Simulation):
         else:
             structure = self.S
 
-        if distances == []:
+        if len(distances) == 0:
             # if no distances are set, calculate the extinction on
             # the middle of each unit cell
             d_start, _, distances = structure.get_distances_of_layers(False)
@@ -695,7 +694,7 @@ class Heat(Simulation):
         # initialize
         t1 = time()
         backside = self._excitation['backside']
-        if distances == []:
+        if len(distances) == 0:
             # if no distances are set, calculate the extinction on
             # the middle of each unit cell
             d_start, _, distances = self.S.get_distances_of_layers(False)
@@ -868,16 +867,16 @@ class Heat(Simulation):
                 start = 0
                 stop = 0
                 if i > 0:
-                    # check if there was a intervall before and add
-                    # last time of this intervall to the current
+                    # check if there was a interval before and add
+                    # last time of this interval to the current
                     sub_delays = np.r_[checked_excitation[i-1][0][-1], sub_delays]
                     start = 1
                 if i < len(checked_excitation)-1 and \
                         np.sum(checked_excitation[i+1][3]) > 0 and \
                         np.sum(checked_excitation[i+1][2]) == 0:
-                    # there is a next intervall of delta excitation so
+                    # there is a next interval of delta excitation so
                     # we add this time at the end of the current
-                    # intervall
+                    # interval
                     sub_delays = np.r_[sub_delays, checked_excitation[i+1][0][0]]
                     stop = 1
 
@@ -886,9 +885,9 @@ class Heat(Simulation):
                                                 pulse_width, fluence)
 
                 if stop == 1:
-                    # there is an upcomming delta excitation so we have
+                    # there is an upcoming delta excitation so we have
                     # to set the initial temperature for this next
-                    # intervall seperately
+                    # interval separately
                     special_init_temp = temp[-1, :, :]
                     temp = temp[start:-1, :, :]
                 else:
@@ -991,7 +990,7 @@ class Heat(Simulation):
 
         d_distances = np.diff(distances)
         N = len(distances)
-        if fluence != []:
+        if np.any(fluence):
             dAdz = self.get_absorption_profile(distances=distances,
                                                backside=backside)
         else:
@@ -1081,12 +1080,12 @@ class Heat(Simulation):
             temp_map = sol.y.T
 
         temp_map = np.array(temp_map).reshape([M, N, K], order='F')
-        if fluence == []:
-            self.disp_message('Elapsed time for _heat_diffusion_: {:f} s'.format(time()-t1))
-        else:
+        if np.any(fluence):
             self.disp_message('Elapsed time for _heat_diffusion_ with {:d} '
                               'excitation(s): {:f} s'.format(len(fluence), time()-t1))
-
+        else:
+            self.disp_message('Elapsed time for _heat_diffusion_: {:f} s'.format(time()-t1))
+            
         return temp_map
 
     @staticmethod

--- a/udkm1Dsim/simulations/heat.py
+++ b/udkm1Dsim/simulations/heat.py
@@ -920,7 +920,7 @@ class Heat(Simulation):
             if np.sum(fluence) > 0:
                 num_ex += len(fluence)
 
-        if not np.all(excitation_delays == delays.to('s').magnitude) or self.heat_diffusion:
+        if not np.array_equal(excitation_delays, delays.to('s').magnitude) or self.heat_diffusion:
             # if the time grid for the calculation is not the same as
             # the grid to return the results on. Then extrapolate the
             # results on the original delay array but keep the first
@@ -1155,7 +1155,7 @@ class Heat(Simulation):
 
         # calculate external source
         source = np.zeros([N, K])
-        if fluence != []:
+        if np.any(fluence):
             source[:, 0] = \
                 dAdz * multi_gauss(t, s=pulse_length, x0=delay_pump, A=fluence)
 

--- a/udkm1Dsim/simulations/magnetization.py
+++ b/udkm1Dsim/simulations/magnetization.py
@@ -149,12 +149,11 @@ class Magnetization(Simulation):
         except AttributeError:
             pass
 
-        if distances == []:
+        N = len(distances)
+        if N == 0:
             # no spatial grid is provided
             N = self.S.get_number_of_layers()
             [distances, _, _] = self.S.get_distances_of_layers(False)
-        else:
-            N = len(distances)
 
         if len(init_mag) == 0:
             self.disp_message('No explicit initial magnetization given '


### PR DESCRIPTION
With recent numpy versions (1.26.3) it is not possible to compare arrays to empty lists resulting in something like ValueError: operands could not be broadcast together with shapes (300,) (0,) . This commit fixes this issue (#151) by changing the check for empty arrays to len()