### PR TITLE
Update requirements in setup.py due to incompatibility with NumPy 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     url='https://github.com/dschick/udkm1Dsim',
     install_requires=['tqdm>=4.43.0',
-                      'numpy>=1.18.2',
+                      'numpy>=1.18.2,<2.0.0',
                       'pint>=0.23',
                       'scipy>=1.4.1',
                       'sympy>=1.5.1',


### PR DESCRIPTION
Due to several breaking changes in NumPy 2.0.0, the dependency requirements should be limited to version <2.0.0.